### PR TITLE
Dynamic programming functionality

### DIFF
--- a/lib/github.com/diku-dk/linalg/Makefile
+++ b/lib/github.com/diku-dk/linalg/Makefile
@@ -1,6 +1,6 @@
 FUTHARK?=futhark
 
-TESTS=lu_tests.fut linalg_tests.fut qr_tests.fut nmf_tests.fut lup_tests.fut perm_tests.fut
+TESTS=*_tests.fut
 
 .PHONY: test
 test: $(TESTS)
@@ -12,4 +12,4 @@ doc:
 
 .PHONY: clean
 clean:
-	rm -rf *~ *.c lu_tests linalg_tests nmf_tests qr_tests linalg lup_tests perm_tests nmf lu qr *.actual *.expected doc
+	rm -rf *~ linalg lu lup nmf qr perm dpsolve *.c *_tests *.actual *.expected doc

--- a/lib/github.com/diku-dk/linalg/dpsolve.fut
+++ b/lib/github.com/diku-dk/linalg/dpsolve.fut
@@ -87,7 +87,7 @@ module type dpsolve = {
   -- approximations (maximum of each dimension).
   val poly [m] : (f: [m]t -> ([m]t,mat[m])) -> (v:[m]t) -> (p:param)
                  -> (b:t) -> {res:[m]t, jac:mat[m], conv:bool, iter_sa:i64,
-			      iter_nk:i64, rtrips: i64, tol:t}
+                              iter_nk:i64, rtrips: i64, tol:t}
 
   -- | Find a fix-point for the function `f` using a combination of successive
   -- approximation iterations and Newton-Kantorovich iterations. The initial
@@ -101,7 +101,7 @@ module type dpsolve = {
   -- fix-point approximations (maximum of each dimension).
   val polyad [m] : (f:[m]t->[m]t) -> (v:[m]t) -> (p:param) -> (b:t)
                    -> {res:[m]t, conv:bool, iter_sa:i64, iter_nk: i64,
-		       rtrips:i64, tol:t}
+                       rtrips:i64, tol:t}
 }
 
 -- | Module type specifying a linear equations solver and functionality for
@@ -229,7 +229,7 @@ module mk_dpsolve (T:real)
                (V0:[m]t)
                (ap:param)
                (bet:t) : {res:[m]t, jac:mat [m], conv:bool, iter_sa:i64,
-			  iter_nk:i64, rtrips:i64, tol:t} =
+                          iter_nk:i64, rtrips:i64, tol:t} =
     loop {res=V0,jac=_dV,conv=converged,iter_sa=i,iter_nk=j,rtrips=k,tol=_tol} =
       {res=V0, jac=ols_jac.zero m, conv=false, iter_sa=0, iter_nk=0, rtrips=0, tol=T.i64 1}
       while !converged && k < ap.max_fxpiter do

--- a/lib/github.com/diku-dk/linalg/dpsolve.fut
+++ b/lib/github.com/diku-dk/linalg/dpsolve.fut
@@ -1,0 +1,217 @@
+-- | Generic solver for fix-point (Bellman) equations. This module implements a
+-- generic solver for finding solutions to fix-point (Bellman) equations. The
+-- module may be used for finding solutions to dynamic programming problems. The
+-- implementation is based on John Rust's poly-algorithm, which combines the
+-- strategies of successive applications and the Newton-Kantorovich method.
+--
+-- The module is enriched with a version of the solver that uses Futhark's
+-- support for automatic differentiation (forward mode AD) to compute the
+-- Jacobian for the passed fix-point function.
+--
+-- For more details, see Rust's description in Section 4 of
+-- https://editorialexpress.com/jrust/sdp/ndp.pdf and a demonstration of its use
+-- in https://elsman.com/pdf/dpsolver_demo.pdf.
+
+import "lu"
+
+local
+-- | Module type specifying generic solvers for Bellman equations. Notice that
+-- this module type is declared `local`, which means that it cannot directly be
+-- referenced by name from the outside.  By not exposing the module type, the
+-- module may be extended with new members in minor versions.
+module type dpsolve = {
+  -- | The scalar type.
+  type t
+
+  -- | The type of solver parameters.
+  type param = {
+    sa_max          : i64,  -- Maximum and minimum numbers of
+    sa_min          : i64,  --   successive approximation steps.
+    sa_tol          : t,    -- Stopping tolerance for successive
+                            --   approximation.
+    max_fxpiter     : i64,  -- Maximum number of times to switch
+                            --   between Newton-Kantorovich and
+                            --   successive approximation iterations.
+    pi_max          : i64,  -- Maximum number of Newton-Kantorovich steps.
+    pi_tol          : t,    -- Final exit tolerance in fixed point
+                            --   algorithm, measured in units of
+                            --   numerical precision
+    tol_ratio       : t     -- Relative tolerance before switching
+                            --   to N-K algorithm when discount factor is
+                            --   supplied as input in `poly`.
+    }
+
+  -- | The default parameter value
+  val default : param
+
+  -- | Find a fix-point for the function `f` using successive approximation with
+  -- the initial guess `v`, parameter `p`, and beta-value `b`. The tolerance,
+  -- the minimal, and the maximal number of iterations can be adjusted by
+  -- altering the parameter `p`. The argument `b` is the beta discount factor,
+  -- which allows for stopping early (when the relative tolerance is close to
+  -- `b`). The function returns a quintuple containing an approximate fix-point,
+  -- a boolean specifying whether the algorithm converged (according to the
+  -- values in `p`), the number of iterations used, and finally, the tolerance
+  -- and the relative tolerance of the last two fix-point approximations and the
+  -- last two tolerances, respectively (maximum of each dimension).
+  val sa [m] : (f:[m]t->[m]t) -> (v:[m]t) -> (p:param) -> (b:t)
+               -> ([m]t, bool, i64, t, t)
+
+  -- | Find a fix-point for the function `f` using Newton-Kantorovich iterations
+  -- with the initial guess `v`, and parameter `p`. The tolerance, the minimal,
+  -- and the maximal number of iterations can be adjusted by altering the
+  -- parameter `p`. The function `f` should return a pair of a new next
+  -- approximation and the Jacobian matrix for the function `f` relative to the
+  -- argument given. The function returns a quintuple containing an approximate
+  -- fix-point, a Jacobian matrix for the fix-point, a boolean specifying whether
+  -- the algorithm converged (according to the values in `p`), the number of
+  -- iterations used, and finally, the tolerance of the last two fix-point
+  -- approximations (maximum of each dimension).
+  val nk [m] : (f: [m]t -> ([m]t,[m][m]t)) -> (v:[m]t) -> (p:param)
+               ->  ([m]t, [m][m]t, bool, i64, t)
+
+  -- | Find a fix-point for the function `f` using a combination of successive
+  -- approximation iterations and Newton-Kantorovich iterations. The initial
+  -- guess is `v` and the parameter `p` is passed to the calls to `sa` and
+  -- `nk`. The function `f` should return a pair of a new next approximation and
+  -- the Jacobian matrix for the function `f` relative to the argument
+  -- given. The function returns a 7-tuple containing an approximate fix-point, a
+  -- Jacobian matrix for the fix-point, a boolean specifying whether the
+  -- algorithm converged (according to the values in `p`), the number of
+  -- iterations used for the total sa iterations, the total nk iterations, and
+  -- the number of round-trips. The 7'th element of the result tuple is the
+  -- tolerance of the last two fix-point approximations (maximum of each
+  -- dimension).
+  val poly [m] : (f: [m]t -> ([m]t,[m][m]t)) -> (v:[m]t) -> (p:param)
+                 -> (b:t) -> ([m]t,[m][m]t,bool,i64,i64,i64,t)
+
+  -- | Find a fix-point for the function `f` using a combination of successive
+  -- approximation iterations and Newton-Kantorovich iterations. The initial
+  -- guess is `v` and the parameter `p` is passed to the calls to `sa` and
+  -- `nk`. The function uses forward-mode automatic differentiation to compute
+  -- the Jacobian matrix relative to the argument given to `f`. The function
+  -- returns a 6-tuple containing an approximate fix-point, a boolean specifying
+  -- whether the algorithm converged (according to the values in `p`), the
+  -- number of iterations used for the total sa iterations, the total nk
+  -- iterations, and the number of round-trips. The 6'th element of the result
+  -- tuple is the tolerance of the last two fix-point approximations (maximum of
+  -- each dimension).
+  val polyad [m] : (f:[m]t->[m]t) -> (v:[m]t) -> (p:param) -> (b:t)
+                   -> ([m]t, bool, i64, i64, i64, t)
+}
+
+-- | Parameterised module for creating generic solvers.
+
+module mk_dpsolve (r:real) : dpsolve with t = r.t = {
+
+  type t = r.t
+  local module lu = mk_lu r
+
+  def blksz : i64 = 16  -- 1 or 16
+
+  def ols [n] (m:[n][n]t) (b:[n]t) : [n]t =
+    lu.ols blksz m b
+
+  def eye (n:i64) (m:i64) : [n][m]t =
+    tabulate_2d n m (\i j -> r.bool (i == j))
+
+  def zero (n:i64) (m:i64) : [n][m]t =
+    replicate n (replicate m (r.i64 0))
+
+  type param = {
+    sa_max          : i64,  -- Maximum number of contraction steps
+    sa_min          : i64,  -- Minimum number of contraction steps
+    sa_tol          : t,    -- Absolute tolerance before (in dpsolve.poly: tolerance before switching
+                            --   to N-K algorithm)
+    max_fxpiter     : i64,  -- Maximum number of times to switch between Newton-Kantorovich iterations
+                            --   and contraction iterations.
+    pi_max          : i64,  -- Maximum number of Newton-Kantorovich steps
+    pi_tol          : t,    -- Final exit tolerance in fixed point algorithm, measured in units of
+                            --   numerical precision
+    tol_ratio       : t     -- Relative tolerance before switching to N-K algorithm
+                            --   when discount factor is supplied as input in dpsolve.poly
+  }
+
+  def default : param =
+    {sa_max      = 20,
+     sa_min      = 2,
+     sa_tol      = r.f64 1.0e-3,
+     max_fxpiter = 35,
+     pi_max      = 40,
+     pi_tol      = r.f64 1.0e-13,
+     tol_ratio   = r.f64 1.0e-03
+    }
+
+  def sa [m] (bellman : [m]t -> [m]t)
+             (V0:[m]t)
+             (ap:param)
+             (bet:t) : ([m]t, bool, i64, t, t) =
+      loop (V0,converged,i,tol,_rtol) = (V0, false, 0, r.i64 0, r.i64 0)
+      while !converged && i < ap.sa_max do
+        let V = bellman V0
+	let tol' = reduce r.max (r.i64 0) (map2 (\a b -> r.(abs(a-b))) V V0)
+	let rtol' = if i == 1 then r.i64 1
+	 	    else r.(tol' / tol)
+	let converged =
+             -- Rule 1
+             (i > ap.sa_min && (r.(abs(bet-rtol') < ap.tol_ratio)))
+          || -- Rule 2
+             --let adj = f64.(maximum V0 |> abs |> log10 |> ceil)
+             --let ltol = ap.sa_tol * f64.(10 ** adj)
+	     let ltol = ap.sa_tol
+             in (i > ap.sa_min && r.(tol' < ltol))
+	in (V, converged, i+1, tol',rtol')
+
+  def nk [m] (bellman : [m]t -> ([m]t,[m][m]t))
+             (V0:[m]t)
+             (ap:param) : ([m]t, [m][m]t, bool, i64, t) =
+    loop (V0,_dV0,converged,i,_tol) = (V0, zero m m, false, 0, r.i64 1)
+      while !converged && i < ap.pi_max do
+        let (V1, dV) = bellman V0
+        --let V = map2 (-) V0 (la.matvecmul_row (la.inv dV) V1)
+	let F = map2 (map2 (r.-)) (eye m m) dV
+  	--let _hermitian =
+	--  map2 (map2 (r.==)) F (transpose F) |> map (reduce (&&) true) |> reduce (&&) true
+	let V = map2 (r.-) V0 (ols F (map2 (r.-) V0 V1))  -- NK-iteration
+	-- do additional SA iteration for stability and accurate measure of error bound
+	let (V0, _) = bellman V
+	let tol' = r.maximum (map2 (\a b -> r.(abs(a-b))) V V0) -- tolerance
+
+	-- adjusting the N-K tolerance to the magnitude of ev
+	let adj = r.(maximum V0 |> abs |> log10 |> ceil)
+	let ltol = r.(ap.pi_tol * (i64 10 ** adj)) -- Adjust final tolerance
+        -- ltol=ap.pi_tol  -- tolerance
+
+        let converged = r.(tol' < ltol) -- Convergence achieved
+        in (V0, dV, converged, i+1, tol')
+
+  -- dpsolve.poly(f,v0,ap,bet): Solve for fixed point using a combination of
+  -- Successive Approximations (SA) and Newton-Kantorovich (NK) iterations.  The
+  -- argument `ap` holds algorithm parameters. The argument `bet` is a discount
+  -- factor. Enters rule for stopping SA and switching to NK iterations.  SA
+  -- should stop prematurely when relative tolerance is close to bet.  The
+  -- argument `v0` is the initial value guess. The function returns a fix-point
+  -- `V`, the Frechet derivative of the Bellman operator, and various count
+  -- information including the obtained tolerance.
+
+  def poly [m] (bellman : [m]t -> ([m]t,[m][m]t))
+               (V0:[m]t)
+               (ap:param)
+               (bet:t) : ([m]t,[m][m]t,bool,i64,i64,i64,t) =
+    loop (V0,_dV,converged,i,j,k,_tol) = (V0, zero m m, false, 0, 0, 0, r.i64 1)
+      while !converged && k < ap.max_fxpiter do
+        -- poly-algorithm loop (switching between sa and nk)
+        let (V1,_,i',_,_) = sa ((.0) <-< bellman) V0 ap bet
+	let (V2, dV, c2, j', tol) = nk bellman V1 ap
+        in (V2,dV,c2,i+i',j+j',k+1,tol)
+
+  def idd n i = tabulate n (\j -> if i==j then r.f32 1 else r.f32 0)
+
+  def wrapj [n][m] (f: [n]t->[m]t) (x:[n]t) : ([m]t,[m][n]t) =
+    (f x, #[sequential_outer] tabulate n (jvp f x <-< idd n) |> transpose)
+
+  def polyad f x ap bet =
+    let (y,_,b,i,j,k,tol) = poly (wrapj f) x ap bet
+    in (y,b,i,j,k,tol)
+
+}

--- a/lib/github.com/diku-dk/linalg/dpsolve.fut
+++ b/lib/github.com/diku-dk/linalg/dpsolve.fut
@@ -10,7 +10,7 @@
 --
 -- For more details, see Rust's description in Section 4 of
 -- https://editorialexpress.com/jrust/sdp/ndp.pdf and a demonstration of its use
--- in https://elsman.com/pdf/dpsolver_demo.pdf.
+-- in https://elsman.com/pdf/dpsolve-2025-09-27.pdf.
 
 import "lu"
 

--- a/lib/github.com/diku-dk/linalg/dpsolve_tests.fut
+++ b/lib/github.com/diku-dk/linalg/dpsolve_tests.fut
@@ -1,7 +1,7 @@
 -- | ignore
 
 import "dpsolve"
-module dps = mk_dpsolve f64
+module dps = mk_dpsolve_dense f64
 
 def bellman (x:[2]f64) : [2]f64 =
   [f64.sqrt x[1], f64.sqrt(1 - x[0] ** 2)]

--- a/lib/github.com/diku-dk/linalg/dpsolve_tests.fut
+++ b/lib/github.com/diku-dk/linalg/dpsolve_tests.fut
@@ -1,0 +1,174 @@
+-- | ignore
+
+import "dpsolve"
+module dps = mk_dpsolve f64
+
+def bellman (x:[2]f64) : [2]f64 =
+  [f64.sqrt x[1], f64.sqrt(1 - x[0] ** 2)]
+
+entry test_sa (sa_max:i64) (sa_tol:f64) : ([2]f64, bool, i64, f64) =
+  let v0 = [0.5, 0.5]
+  let ap = dps.default with sa_max = sa_max
+                       with sa_tol = sa_tol
+  let (res, b, i, tol, _) = dps.sa bellman v0 ap 0
+  in (res, b, i, tol)
+
+-- ==
+-- entry: test_sa
+-- input { 60i64 1e-3 } output { [0.785513763, 0.617747547] true 56i64 8.769119278e-4f64 }
+-- input { 200i64 1e-9 } output { [0.786151372, 0.618033989] true 186i64 9.120002530e-10f64 }
+
+def bellman_j (a:[2]f64) : ([2]f64, [2][2]f64) =
+  let x1 = a[0]
+  let x2 = a[1]
+  let res = [f64.sqrt x2, f64.sqrt(1-x1**2)]
+  let j = [[0                       , 1/(2*f64.sqrt x2) ],
+           [-x1/(f64.sqrt(1-x1**2)) , 0                 ]]
+  in (res, j)
+
+entry test_poly (sa_max:i64) : ([2]f64, bool, i64, i64, i64, f64) =
+  let v0 = [0.5, 0.5]
+  let ap = dps.default with sa_max = sa_max
+  let (res, _, b, i, j, k, tol) = dps.poly bellman_j v0 ap 0
+  in (res, b, i, j, k, tol)
+
+-- ==
+-- entry: test_poly
+-- input { 5i64 } output { [0.786151377, 0.6180339887] true 5i64 4i64 1i64 1.11022302e-16f64 }
+
+def idd n i = tabulate n (f64.bool <-< (==i))
+
+def wrapj [n][m] (f: [n]f64->[m]f64) (x:[n]f64) : ([m]f64,[m][n]f64) =
+  (f x, tabulate n (jvp f x <-< idd n) |> transpose)
+
+entry test_poly_jvp (sa_max:i64) : ([2]f64,bool,i64,i64,i64,f64) =
+  let v0 = [0.5, 0.5]
+  let ap = dps.default with sa_max = sa_max
+  let (res, _, b, i, j, k, tol) =
+    dps.poly (wrapj bellman) v0 ap 0
+  in (res, b, i, j, k, tol)
+
+-- ==
+-- entry: test_poly_jvp
+-- input { 5i64 } output { [0.78615137, 0.618033988] true 5i64 4i64 1i64 1.110223024e-16f64 }
+
+entry test_polyad (sa_max:i64) : ([2]f64,bool,i64,i64,i64,f64) =
+  let v0 = [0.5, 0.5]
+  let ap = dps.default with sa_max = sa_max
+  in dps.polyad bellman v0 ap 0
+
+-- ==
+-- entry: test_polyad
+-- input { 5i64 } output { [0.78615137, 0.618033988] true 5i64 4i64 1i64 1.11022302e-16f64 }
+
+def bellmanr (r:f64) (a:[2]f64) : ([2]f64, [2][2]f64) =
+  let f (a:[2]f64) = [f64.sqrt a[1], f64.sqrt(r**2-a[0]**2)]
+  let res = f a
+  let j = [[0                            , 1/(2*f64.sqrt a[1]) ],
+           [-a[0]/f64.sqrt(r**2-a[0]**2) , 0                   ]]
+  in (res, j)
+
+-- We then create an entry point that implements an outer map over a
+-- call to `dps.poly` with varying radius:
+
+def linspace (n: i64) (start: f64) (end: f64) : [n]f64 =
+  tabulate n (\i -> start + f64.i64 i * ((end-start)/f64.i64 n))
+
+entry test_polyr (n:i64) (sa_max:i64) : (bool, i64, [n]f64, [n]f64) =
+  let ap = dps.default with sa_max = sa_max
+  let rs = linspace n 1 20
+  let ress = map (\r -> let v0 = [0.5,0.5]
+                        let (res, _, b, i, j, _k, _tol) =
+                          dps.poly (bellmanr r) v0 ap 0
+                        in (r,res[0],b,i+j)) rs
+  let converged = reduce (&&) true (map (.2) ress)
+  let xs = map (.1) ress
+  let iterations = reduce (+) 0 (map (.3) ress)
+  in (converged, iterations, rs, xs)
+
+-- ==
+-- entry: test_polyr
+-- input { 4i64 3i64 } output { true 25i64 [1.0,5.75,10.5,15.25] [0.786151377,2.29601789,3.1641583,3.84163956] }
+
+entry test_poly1d (sa_max : i64) : ([1]f64, [1][1]f64, bool, i64, i64, i64, f64) =
+  let ap = dps.default with sa_max = sa_max
+  in dps.poly (\x -> ([f64.cos x[0]],
+                      [[- f64.sin x[0]]]))
+              [0.7] ap 0
+
+-- ==
+-- entry: test_poly1d
+-- input { 0i64 } output { [0.739085133] [[-0.6736120230]] true 0i64 3i64 1i64 0.0 }
+
+entry test_sqrt (sa_max : i64) : [1]f64 =
+  let ap = dps.default with sa_max = sa_max
+  in dps.poly (\x -> ( [ 0.5 * (x[0]+2/x[0]) ],
+                       [[ 2*x[0] ]] )
+              ) [1.4] ap 0 |> (.0)
+
+-- ==
+-- entry: test_sqrt
+-- input { 0i64 } output { [1.414213562] }
+
+def dotprod [n] (u:[n]f64) (v:[n]f64) : f64 =
+  reduce (+) 0.0 (map2 (*) u v)
+
+def matvecmul [n][m] (A: [n][m]f64) (v: [m]f64) : [n]f64 =
+  map (dotprod v) A
+
+def matmul [n][p][m] (us: [n][p]f64) (vs: [p][m]f64) : [n][m]f64 =
+  map (matvecmul (transpose vs)) us
+
+def binop [n] (f:f64->f64->f64) (a:[n][n]f64) (b:[n][n]f64) : [n][n]f64 =
+  map2 (map2 f) a b
+
+def diag_ex [n] (A:[n][n]f64) : [n]f64 =
+  map (\i -> A[i][i]) (iota n)
+
+def diag [n] (a:[n]f64) : [n][n]f64 =
+  tabulate_2d n n (\i j -> if i == j then a[i] else 0.0)
+
+def jacobi [n] (A:[n][n]f64) (b:[n]f64) : [n]f64 -> [n]f64 =
+  let D' = diag_ex A |> map (1.0/) |> diag -- D^{-1}
+  let I = diag (tabulate n (\_ -> 1.0))
+  let G = binop (-) I (matmul D' A)
+  let f = map (\i -> D'[i][i]*b[i]) (iota n)
+  in \x -> map2 (+) (matvecmul G x) f
+
+def eqv_eps [n] (eps:f64) (x:[n]f64) (y:[n]f64) =
+  map2 (\a b -> f64.abs(a-b) < eps) x y |> reduce (&&) true
+
+entry test_jacobi [n] (A:[n][n]f64) (b:[n]f64) (k:i64) : [n]f64 =
+  let pow f k x = loop x for _i < k do f x
+  let f = jacobi A b
+  in pow f k (replicate n 1f64)
+
+-- ==
+-- entry: test_jacobi
+-- input { [[3f64,1,-1],[1.0,-1,2],[-1.0,1,-3]] [1f64,8,-1] 5i64 }
+-- output { [2.96707818, -12.2839506, -4.193415637] }
+-- input { [[3f64,1,-1],[1.0,-1,2],[-1.0,1,-3]] [1f64,8,-1] 50i64 }
+-- output { [3.999950534, -17.9976114, -6.99987789] }
+-- input { [[3f64,1,-1],[1.0,-1,2],[-1.0,1,-3]] [1f64,8,-1] 51i64 }
+-- output { [3.999960453, -17.9998044, -6.99998946] }
+
+entry test_jacobi_ok : bool =
+  let A = [[3f64,1,-1],[1.0,-1,2],[-1.0,1,-3]]
+  let b = [1f64,8,-1]
+  in eqv_eps 0.0001 (matvecmul A (test_jacobi A b 51)) b
+
+-- ==
+-- entry: test_jacobi_ok
+-- input { } output { true }
+
+entry test_jacobi_polyad (sa_max: i64) : [3]f64 =
+  let A = [[3f64,1,-1],[1.0,-1,2],[-1.0,1,-3]]
+  let b = [1f64,8,-1]
+  let f = jacobi (copy A) (copy b)
+  let x0 = replicate 3 1f64
+  let ap = dps.default with sa_max = sa_max
+  in dps.polyad f x0 ap 0 |> (.0)
+
+-- ==
+-- entry: test_jacobi_polyad
+-- input { 2i64 } output { [4.0,-18,-7] }


### PR DESCRIPTION
Add the module `dpsolve`.

The module is now parameterised over a linear equations solver together with a diff implementation. A particular instantiation `mk_dpsolve_dense` uses a dense linear solver and the Futhark AD function `jvp`.  Other instantiations are possible. For instance, one can imagine that we could instantiate the `dp_solve` module with a sparse implementation of linear equation solving and functionality for returning a sparse Jacobian. I'm not sure, however, how we can create such a sparse Jacobian?!

Some relevant links:

- https://optimization-online.org/wp-content/uploads/2002/02/445.pdf
- https://iclr-blogposts.github.io/2025/blog/sparse-autodiff/
